### PR TITLE
Fail deploy hook steps on updater errors

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         env:
           UPDATER_KEY: ${{ secrets.UPDATER_KEY }}
-        run: curl -fsS "https://hooks.terrty.net/update/zabbix/${UPDATER_KEY}"
+        run: curl -fsS --connect-timeout 30 --retry 2 --retry-delay 5 "https://hooks.terrty.net/update/zabbix/${UPDATER_KEY}"
 
       - name: build LHCI server image without pushing (only outside master)
         working-directory: config/lhci
@@ -73,4 +73,4 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         env:
           UPDATER_KEY: ${{ secrets.UPDATER_KEY }}
-        run: curl -fsS "https://hooks.terrty.net/update/lhci/${UPDATER_KEY}"
+        run: curl -fsS --connect-timeout 30 --retry 2 --retry-delay 5 "https://hooks.terrty.net/update/lhci/${UPDATER_KEY}"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         env:
           UPDATER_KEY: ${{ secrets.UPDATER_KEY }}
-        run: curl https://hooks.terrty.net/update/zabbix/${UPDATER_KEY}
+        run: curl -fsS "https://hooks.terrty.net/update/zabbix/${UPDATER_KEY}"
 
       - name: build LHCI server image without pushing (only outside master)
         working-directory: config/lhci
@@ -73,4 +73,4 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         env:
           UPDATER_KEY: ${{ secrets.UPDATER_KEY }}
-        run: curl https://hooks.terrty.net/update/lhci/${UPDATER_KEY}
+        run: curl -fsS "https://hooks.terrty.net/update/lhci/${UPDATER_KEY}"

--- a/.github/workflows/ci-pull.yml
+++ b/.github/workflows/ci-pull.yml
@@ -14,4 +14,4 @@ jobs:
       - name: pull newest code to terrty.net from master
         env:
           UPDATER_KEY: ${{ secrets.UPDATER_KEY }}
-        run: curl -fsS "https://hooks.terrty.net/update/pull-code/${UPDATER_KEY}"
+        run: curl -fsS --connect-timeout 30 --retry 2 --retry-delay 5 "https://hooks.terrty.net/update/pull-code/${UPDATER_KEY}"

--- a/.github/workflows/ci-pull.yml
+++ b/.github/workflows/ci-pull.yml
@@ -14,4 +14,4 @@ jobs:
       - name: pull newest code to terrty.net from master
         env:
           UPDATER_KEY: ${{ secrets.UPDATER_KEY }}
-        run: curl https://hooks.terrty.net/update/pull-code/${UPDATER_KEY}
+        run: curl -fsS "https://hooks.terrty.net/update/pull-code/${UPDATER_KEY}"


### PR DESCRIPTION
Previously, the three deploy hook curls ignored HTTP errors, so a failing updater task left CI green while the deployment silently did not happen - this masked a broken `git pull --ff-only` on the server for over a week. The updater returns HTTP 500 when a task command fails; after this change curl propagates that as a step failure (`-fsS`). The URL is quoted to satisfy shellcheck SC2086.

Found during a full repo review; the server-side tree drift that caused the silent failures has been reconciled separately.