### PR TITLE
Replace abandoned jamielsharief/mysql image with official mysql:8.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,7 @@ services:
       - ZBX_SERVER_HOST=zabbix-server
 
   mysql:
-    image: jamielsharief/mysql:latest
+    image: mysql:8.4
     container_name: mysql
     command:
       - mysqld
@@ -165,7 +165,10 @@ services:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       start_period: 1m
 
-    # MYSQL_DATABASE, MYSQL_PASSWORD, MYSQL_USER
+    # MYSQL_DATABASE, MYSQL_PASSWORD, MYSQL_USER, MYSQL_ROOT_PASSWORD
+    # MYSQL_ROOT_PASSWORD is required by the official image to initialise an
+    # empty data directory (fresh deploy or restore); it is ignored once
+    # ./private/mysql-data is populated.
     env_file: private/environment/mysql.env
     environment:
       - TZ=UTC


### PR DESCRIPTION
Previously, MySQL ran from `jamielsharief/mysql:latest`, a personal image last pushed on 2022-08-13, freezing the server at MySQL 8.0.30 (Ubuntu 20.04 build) with almost four years of unpatched CVEs. This switches to the official `mysql:8.4` LTS image, which supports arm64, keeps the socket at `/var/run/mysqld/mysqld.sock`, uses the same mysql uid/gid 999, and receives updates until 2032.

Verified against the running server before proposing:
- All accounts already use `caching_sha2_password` (zabbix, root, mysql.*), so the 8.4 removal of `mysql_native_password` does not affect any existing user.
- The server's `mysql.env` already defines `MYSQL_ROOT_PASSWORD`; the official image needs it only to initialise an empty data directory, and it is ignored once `./private/mysql-data` is populated. Documented in the compose comment.
- In-place upgrade 8.0.30 -> 8.4 is a documented supported path.

Deploy note: the datadir upgrade on first start is one-way, so take a dump before running `docker compose up -d mysql`.

Found during a full repo review.