### PR TITLE
Document the zabbix-web DB_SERVER_PORT workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,19 @@
 - Sync files with: `rsync -avz <file> terrty:~/terrty/<path>`
 - Apply changes: `ssh terrty "cd ~/terrty && docker compose up -d"`
 - All services defined in `docker-compose.yml`
+
+## Gotchas
+- **`zabbix-web` needs `DB_SERVER_PORT=3306` even though it connects via the MySQL socket.**
+  Zabbix 7.4.11 changed the frontend config template from `getenv('DB_SERVER_PORT')` (returns
+  `false` when unset, coerced to `int 0`) to `env_string('DB_SERVER_PORT')` (returns `''` when
+  unset). Under PHP 8 an empty string is invalid for `mysqli::real_connect()`'s `?int $port`
+  argument, so an unset port throws a fatal `TypeError` and every frontend page returns HTTP 500.
+  Setting a numeric port sidesteps it; the value is ignored because the connection uses the socket.
+  This is applied on the server via an untracked `docker-compose.override.yml`, so do not delete
+  that file.
+  - Fixed upstream in zabbix-docker `cc028ed` (2026-07-01, branches `master` + `7.4`), which
+    replaces `env_string` with an `env_int` helper.
+  - **Waiting for a fixed published image:** as of 2026-07-05 no stable image contains the fix.
+    The newest stable `zabbix/zabbix-web-nginx-mysql` tags (`latest`, `7.4.11`) predate it
+    (2026-06-21 and 2026-06-03); only the `trunk-*` nightlies carry it. Once a stable `7.4.x`
+    image published after 2026-07-01 appears, drop `DB_SERVER_PORT` and this override.


### PR DESCRIPTION
Documents the operational gotcha found during the MySQL 8.4 deploy: `zabbix-web` needs `DB_SERVER_PORT=3306` despite connecting via the MySQL socket, because Zabbix 7.4.11 switched the frontend config from `getenv()` to `env_string()`, which returns `''` when unset and throws a fatal `TypeError` under PHP 8 (HTTP 500 on every page).

The upstream fix (zabbix-docker `cc028ed`, 2026-07-01) is merged but not yet in any published stable image, so the server carries an untracked `docker-compose.override.yml` with the setting. This note records the workaround and the condition under which it can be removed (a stable `7.4.x` image published after 2026-07-01), so the override is not deleted prematurely.

Documentation only.