### PR TITLE
Track zabbix-web DB_SERVER_PORT instead of an untracked override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,11 @@
   unset). Under PHP 8 an empty string is invalid for `mysqli::real_connect()`'s `?int $port`
   argument, so an unset port throws a fatal `TypeError` and every frontend page returns HTTP 500.
   Setting a numeric port sidesteps it; the value is ignored because the connection uses the socket.
-  This is applied on the server via an untracked `docker-compose.override.yml`, so do not delete
-  that file.
+  This is set on `zabbix-web` in the tracked `docker-compose.yml`, so it survives a fresh checkout
+  or server rebuild (an earlier untracked `docker-compose.override.yml` is now redundant).
   - Fixed upstream in zabbix-docker `cc028ed` (2026-07-01, branches `master` + `7.4`), which
     replaces `env_string` with an `env_int` helper.
   - **Waiting for a fixed published image:** as of 2026-07-05 no stable image contains the fix.
     The newest stable `zabbix/zabbix-web-nginx-mysql` tags (`latest`, `7.4.11`) predate it
     (2026-06-21 and 2026-06-03); only the `trunk-*` nightlies carry it. Once a stable `7.4.x`
-    image published after 2026-07-01 appears, drop `DB_SERVER_PORT` and this override.
+    image published after 2026-07-01 appears, drop the `DB_SERVER_PORT` env var.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,12 @@ services:
     environment:
       - TZ=UTC
       - DB_SERVER_SOCKET=/var/run/mysqld/mysqld.sock
+      # Required despite the socket connection: Zabbix 7.4.11's frontend config uses
+      # env_string('DB_SERVER_PORT'), which returns '' when unset and throws a fatal
+      # TypeError under PHP 8 (HTTP 500 on every page). The value is ignored because the
+      # connection uses the socket. Fixed upstream in zabbix-docker cc028ed (2026-07-01);
+      # remove once a stable zabbix-web-nginx-mysql image published after that date ships.
+      - DB_SERVER_PORT=3306
       - ZBX_SERVER_HOST=zabbix-server
       - PHP_TZ=Europe/Moscow
     expose:


### PR DESCRIPTION
Follow-up to #13. A codex review flagged that the `DB_SERVER_PORT=3306` workaround lived only in an untracked `docker-compose.override.yml` on the server, so a fresh checkout or server rebuild from the repo would omit it and `zabbix-web` would 500 again.

The value is not a secret, so this sets it directly on `zabbix-web` in the tracked `docker-compose.yml` (with the same why + removal condition as the CLAUDE.md gotcha) and updates that note to match. Verified: `docker compose config` against the server env yields `DB_SERVER_PORT: "3306"` from the tracked file alone.

Stacked on #13; base will retarget to master once #13 merges. After this deploys, the redundant server-side `docker-compose.override.yml` can be removed.

Documentation + one tracked env var; no secrets.