### PR TITLE
Clean up nginx config

### DIFF
--- a/config/nginx/conf.d/adminer.conf
+++ b/config/nginx/conf.d/adminer.conf
@@ -7,7 +7,7 @@ server {
 	listen 443 ssl;
 	server_name  adminer.terrty.net;
 	allow 77.166.0.0/16; # You shall not pass!
-	allow 172.19.0.1; # IPv6 inside Docker
+	allow 172.16.0.0/12; # docker bridge gateway range; IPv6 clients arrive here via docker-proxy
 	deny all;
 	client_max_body_size 20m;
 	location / {

--- a/config/nginx/conf.d/newscope.terrty.net.conf
+++ b/config/nginx/conf.d/newscope.terrty.net.conf
@@ -11,7 +11,7 @@ server {
         auth_basic_user_file /etc/nginx/htpasswd/newscope.htpasswd;
         
         allow 77.166.0.0/16; # You shall not pass!
-        allow 172.19.0.1; # IPv6 inside Docker
+        allow 172.16.0.0/12; # docker bridge gateway range; IPv6 clients arrive here via docker-proxy
         deny all;
         
         proxy_set_header X-Real-IP $remote_addr;

--- a/config/nginx/conf.d/terrty.net.conf
+++ b/config/nginx/conf.d/terrty.net.conf
@@ -51,7 +51,7 @@ server {
 
 server {
 	listen 80 default_server;
-	server_name .terrty.net .terrty.com .terrty.dev .paskal.dev, .pask.al;
+	server_name .terrty.net .terrty.com .terrty.dev .paskal.dev .pask.al;
 	return 301 https://terrty.net$request_uri;
 }
 

--- a/config/nginx/conf.d/terrty.net.rewrites.conf
+++ b/config/nginx/conf.d/terrty.net.rewrites.conf
@@ -6,7 +6,7 @@ map $request_uri $new_uri {
 	/ru/cv/ /cv/;
 	/2011/binding-keys-to-commands-in-minecraft/ /ru/2011/binding-keys-to-commands-in-minecraft/;
 	/2011/double-click-instead-of-single/ /ru/2011/double-click-instead-of-single/;
-	/2011/etting-16gb-in-dropbox-by-referrals/ /ru/g2011/getting-16gb-in-dropbox-by-referrals/;
+	/2011/getting-16gb-in-dropbox-by-referrals/ /ru/2011/getting-16gb-in-dropbox-by-referrals/;
 	/2011/how-to-make-a-screenshot-in-virtualbox/ /ru/2011/how-to-make-a-screenshot-in-virtualbox/;
 	/2011/olegs-firmware-routers-for-yota-4g-lte/ /ru/2011/olegs-firmware-routers-for-yota-4g-lte/;
 	/2011/setting-up-smtp-relay-server-ssmtp/ /ru/2011/setting-up-smtp-relay-server-ssmtp/;

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -1,5 +1,5 @@
 user  nginx;
-worker_processes  1;
+worker_processes  auto;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
@@ -42,7 +42,7 @@ http {
 	gzip_min_length 1000;
 	gzip_proxied any;
 
-	add_header X-Frame-Options SAMEORIGIN;
+	add_header X-Frame-Options DENY;
 	add_header X-Content-Type-Options nosniff;
 	add_header Alt-Svc 'h3=":443"; ma=86400';
 
@@ -50,20 +50,5 @@ http {
 		text/plain md;
 	}
 
-	server {
-		listen 80;
-		server_name _;
-
-		root   /usr/share/nginx/html;
-
-		location / {  # the default location redirects to https
-			return 301 https://$host$request_uri;
-		}
-	}
-
 	include /etc/nginx/conf.d/*.conf;
-}
-
-stream {
-	include /etc/nginx/stream.d/*.conf;
 }


### PR DESCRIPTION
Grouped nginx hygiene fixes from the repo review, revised per review feedback. Validated with `nginx -t` against the live config tree + certificates.

- **Redirect fix (both typos):** the source URL was missing a `g` (`/2011/etting-16gb…` → `/2011/getting-16gb…`) and the target had a stray `g` (`/ru/g2011/…` → `/ru/2011/…`).
- **allow `172.16.0.0/12` on adminer + newscope** (was a stale `allow 172.19.0.1`): docker assigns bridge subnets from `172.16.0.0/12` ([docs](https://straz.to/2021-09-08-docker-address-pools/)), and IPv6 clients reach nginx as the bridge **gateway** via docker-proxy (the container network is IPv4-only). The terrty network was renumbered `172.19`→`172.18` at some point, which had **silently broken IPv6 access to both vhosts** (403). Broadening to `/12` fixes it robustly against future renumbering.
  - **Known/accepted tradeoff:** because docker-proxy collapses all IPv6 clients to the gateway, this allows any IPv6 client to reach these vhosts. newscope is still protected by Basic Auth; **adminer is intentionally left open over IPv6** (DB credentials still required) per an explicit decision. Not a defect.
- **server_name comma:** `.paskal.dev, .pask.al` → `.paskal.dev .pask.al`.
- **worker_processes** `1` → `auto`; **X-Frame-Options** `SAMEORIGIN` → `DENY` at http level (matches ssl.conf).
- **Dead config:** removed the unreachable port-80 `server_name _` block (`terrty.net.conf` has `listen 80 default_server`) and the `stream{}` include (no `stream.d`).

Note: the earlier remark42 CSP change was dropped — the duplicate header is kept deliberately for the Sentry `report-uri`.