### PR TITLE
Tidy shell scripts

### DIFF
--- a/config/zabbix/externalscripts/sitemap_check.sh
+++ b/config/zabbix/externalscripts/sitemap_check.sh
@@ -20,10 +20,10 @@ if [ -z "$lines" ]; then
 	exit 101
 fi
 
-# check dates in files and get oldest one in unix time (seconds) format
-newest_renewal=$(echo "$lines" | tr '\n' '\0' | xargs -I{} -0 date -d '%Y-%m-%dT%H:%M:%S' +%s -d {} | sort | tail -1)
+# check dates in files and get newest one in unix time (seconds) format
+newest_renewal=$(echo "$lines" | tr '\n' '\0' | xargs -I{} -0 date +%s -d {} | sort | tail -1)
 
 # get age in complete days for newest lastmod entry
-updated_days_ago=$((($(date +%s) - $newest_renewal) / (60 * 60 * 24)))
+updated_days_ago=$((($(date +%s) - newest_renewal) / (60 * 60 * 24)))
 
 echo $updated_days_ago

--- a/scripts/create-zabbix-user.sh
+++ b/scripts/create-zabbix-user.sh
@@ -2,15 +2,15 @@
 
 # Function to create Zabbix user and group
 create_zabbix_user() {
-    echo "Creating zabbix user and group"
-    groupadd -g 1997 zabbix
-    useradd -u 1997 -g zabbix -G docker zabbix
+	echo "Creating zabbix user and group"
+	groupadd -g 1997 zabbix
+	useradd -u 1997 -g zabbix -G docker zabbix
 }
 
 # Function to create and configure the set-zabbix-docker-acl service
 setup_docker_acl_service() {
-    echo "Creating a service 'set-zabbix-docker-acl' which will allow zabbix to read and write docker socket"
-    cat <<EOF >/etc/systemd/system/set-zabbix-docker-acl.service
+	echo "Creating a service 'set-zabbix-docker-acl' which will allow zabbix to read and write docker socket"
+	cat <<EOF >/etc/systemd/system/set-zabbix-docker-acl.service
 [Unit]
 Description=Zabbix docker ACL Hack
 Requires=local-fs.target
@@ -26,25 +26,25 @@ EOF
 
 # Function to install necessary packages and start the service
 configure_and_start_service() {
-    # acl provides setfacl package
-    apt-get -y install acl >/dev/null
-    # enable the service on startup and start it
-    systemctl enable set-zabbix-docker-acl >/dev/null
-    systemctl start set-zabbix-docker-acl
-    echo "Docker permissions for Zabbix Agent is done"
+	# acl provides setfacl package
+	apt-get -y install acl >/dev/null
+	# enable the service on startup and start it
+	systemctl enable set-zabbix-docker-acl >/dev/null
+	systemctl start set-zabbix-docker-acl
+	echo "Docker permissions for Zabbix Agent is done"
 }
 
 # Main function to run all steps
 setup_zabbix_docker() {
-    create_zabbix_user
-    setup_docker_acl_service
-    configure_and_start_service
+	create_zabbix_user
+	setup_docker_acl_service
+	configure_and_start_service
 }
 
 # Check if script is run as root
 if [ "$(id -u)" -ne 0 ]; then
-    echo "This script must be run as root" >&2
-    exit 1
+	echo "This script must be run as root" >&2
+	exit 1
 fi
 
 # Run the main setup function

--- a/scripts/enable-automatic-updates-and-reboots.sh
+++ b/scripts/enable-automatic-updates-and-reboots.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 update_ubuntu() {
-    echo "Updating Ubuntu-based system..."
+	echo "Updating Ubuntu-based system..."
 
-    # Replace /etc/apt/apt.conf.d/50unattended-upgrades
-    cat > /etc/apt/apt.conf.d/50unattended-upgrades << EOL
+	# Replace /etc/apt/apt.conf.d/50unattended-upgrades
+	cat >/etc/apt/apt.conf.d/50unattended-upgrades <<EOL
 Unattended-Upgrade::Allowed-Origins {
     "\${distro_id}:\${distro_codename}";
     "\${distro_id}:\${distro_codename}-kernel";
@@ -21,27 +21,27 @@ Unattended-Upgrade::Automatic-Reboot "true";
 Unattended-Upgrade::Automatic-Reboot-Time "02:00";
 EOL
 
-    # Replace /etc/apt/apt.conf.d/10periodic
-    cat > /etc/apt/apt.conf.d/10periodic << EOL
+	# Replace /etc/apt/apt.conf.d/10periodic
+	cat >/etc/apt/apt.conf.d/10periodic <<EOL
 APT::Periodic::Update-Package-Lists "1";
 APT::Periodic::Download-Upgradeable-Packages "1";
 APT::Periodic::AutocleanInterval "7";
 APT::Periodic::Unattended-Upgrade "1";
 EOL
 
-    # Install and enable unattended-upgrades
-    apt install -y unattended-upgrades
-    systemctl enable unattended-upgrades
-    systemctl start unattended-upgrades
+	# Install and enable unattended-upgrades
+	apt install -y unattended-upgrades
+	systemctl enable unattended-upgrades
+	systemctl start unattended-upgrades
 
-    echo "Ubuntu system updated successfully."
+	echo "Ubuntu system updated successfully."
 }
 
 update_centos() {
-    echo "Updating Yum-based system..."
+	echo "Updating Yum-based system..."
 
-    # Replace /etc/dnf/automatic.conf
-    cat > /etc/dnf/automatic.conf << EOL
+	# Replace /etc/dnf/automatic.conf
+	cat >/etc/dnf/automatic.conf <<EOL
 [commands]
 upgrade_type = default
 random_sleep = 0
@@ -64,28 +64,28 @@ email_to = root
 debuglevel = 1
 EOL
 
-    # Install and enable dnf-automatic
-    dnf install -y dnf-automatic
-    systemctl enable --now dnf-automatic.timer
+	# Install and enable dnf-automatic
+	dnf install -y dnf-automatic
+	systemctl enable --now dnf-automatic.timer
 
-    echo "CentOS-based system updated successfully."
+	echo "CentOS-based system updated successfully."
 }
 
 enable_autoupdate_system() {
-    if [ -f /etc/debian_version ]; then
-        update_ubuntu
-    elif [ -f /etc/redhat-release ]; then
-        update_centos
-    else
-        echo "Unsupported system. This script works only for Ubuntu-based and CentOS-based systems."
-        exit 1
-    fi
+	if [ -f /etc/debian_version ]; then
+		update_ubuntu
+	elif [ -f /etc/redhat-release ]; then
+		update_centos
+	else
+		echo "Unsupported system. This script works only for Ubuntu-based and CentOS-based systems."
+		exit 1
+	fi
 }
 
 # Main execution
 if [ "$(id -u)" -ne 0 ]; then
-    echo "This script must be run as root" >&2
-    exit 1
+	echo "This script must be run as root" >&2
+	exit 1
 fi
 
 enable_autoupdate_system


### PR DESCRIPTION
Grouped shell hygiene from the repo review (finding 15 + scripts formatting).

- **sitemap_check.sh:** dropped the dead first `date -d '%Y-%m-%dT%H:%M:%S'` argument — a second `-d {}` wins, so the format string was never used; corrected the comment that said "oldest" when the code takes the newest `lastmod` (`sort | tail -1`); and dropped the unnecessary `$` on a variable inside `$((…))` (SC2004). Behaviour verified identical (output `0`) in the zabbix-server container before/after.
- **scripts/:** reformatted with `shfmt` to tabs per `.editorconfig` (`indent_style = tab`) — whitespace only.

Verified: `shellcheck` clean, `shfmt -d` clean.